### PR TITLE
Add more options, skip files that are guaranteed to be too long

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Run the executable and give it a directory as well as your [OpenAI secret key](h
 > DoccGPT will attempt to rewrite the contents of every single `.swift` file in the directory that you give it. And if you feed it a sufficiently long file it won't make it all the way to the end!
 
 ```bash
-swift run docc-gpt <directory> --key <key>
+swift run docc-gpt <directory> [--model <model>] [--context-length <context-length>] --key <key> [--skip-files <skip-files>]
 ```
 
 ```bash
@@ -70,7 +70,12 @@ ARGUMENTS:
   <directory>             The folder whose contents you want to document
 
 OPTIONS:
+  -m, --model <model>     The OpenAI model to run (default: text-davinci-003)
+  --context-length <context-length>
+                          The context length corresponding to the OpenAI model chosen. (default: 4096)
   -k, --key <key>         Your secret API key for OpenAI
+  --skip-files <skip-files>
+                          Whether or not files unlikely to documented should be skipped (default: true)
   -h, --help              Show help information.
 ```
 
@@ -104,4 +109,4 @@ That said, I do not think it is far-fetched at all to expect fully automated sel
 
 ## One more thing...
 
-The curious reader may notice that some of the documentation examples used in the prompt come from the inimitable [NSHipster](https://nshipster.com/swift-documentation/). I'm a longtime fan and tremendous appreciator of everything that NSHipster has done for mobile developers all over the world.
+The curious reader may notice that some of the documentation examples used in the prompt come from the inimitable [NSHipster](https://nshipster.com/swift-documentation/). I'm a longtime fan and tremendous appreciator of everything that NSHipster has done for mobile developers everywhere.

--- a/Sources/docc-gpt/DoccGPT.swift
+++ b/Sources/docc-gpt/DoccGPT.swift
@@ -8,7 +8,7 @@ struct DoccGPT: AsyncParsableCommand {
   /// Runs the command.
   mutating func run() async throws {
     let directoryURL = URL(fileURLWithPath: directory)
-    let runner = DoccGPTRunner(apiKey: key)
+    let runner = DoccGPTRunner(apiKey: key, contextLength: contextLength, model: model, skipFiles: skipFiles)
     try await runner.run(in: directoryURL)
   }
 
@@ -18,9 +18,21 @@ struct DoccGPT: AsyncParsableCommand {
   @Argument(help: "The folder whose contents you want to document")
   var directory: String
 
+  /// The OpenAI model to run
+  @Option(name: .shortAndLong, help: "The OpenAI model to run")
+  var model: String = "text-davinci-003"
+
+  /// The context length corresponding to the OpenAI model chosen
+  @Option(name: .long, help: "The context length corresponding to the OpenAI model chosen.")
+  var contextLength: Int = 4096
+
   /// Your secret API key for OpenAI.
   @Option(name: .shortAndLong, help: "Your secret API key for OpenAI")
   var key: String
+
+  /// Whether or not files unlikely to documented should be skipped.
+  @Option(name: .long, help: "Whether or not files unlikely to documented should be skipped")
+  var skipFiles: Bool = true
 }
 
 #if DEBUG

--- a/Sources/docc-gpt/DoccGPTRunnerError.swift
+++ b/Sources/docc-gpt/DoccGPTRunnerError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Errors that can be thrown by the `DoccGPTRunner` class.
-enum DoccGPTRunnerError: Error {
+enum DoccGPTRunnerError: Error, CustomDebugStringConvertible {
   /// Thrown when the enumerator fails to be created.
   case failedToCreateEnumerator
 
@@ -10,4 +10,23 @@ enum DoccGPTRunnerError: Error {
 
   /// Thrown when the responses are missing.
   case missingResponses
+
+  /// Thrown when the OpenAI API returns an error
+  case openAI(String)
+
+  var debugDescription: String {
+    switch self {
+    case .failedToCreateEnumerator:
+      return "Error: Failed to create a file enumerator."
+
+    case .missingResponses:
+      return "Error: Response from API returned zero completions."
+
+    case .missingPrompt:
+      return "Error: Unable to load prompt file."
+
+    case .openAI(let message):
+      return "Error: \(message)."
+    }
+  }
 }

--- a/Sources/docc-gpt/OpenAI.swift
+++ b/Sources/docc-gpt/OpenAI.swift
@@ -41,3 +41,11 @@ struct CompletionResponse: Decodable {
     var text: String
   }
 }
+
+struct ErrorResponse: Decodable {
+  var error: ErrorInfo
+
+  struct ErrorInfo: Decodable {
+    var message: String
+  }
+}


### PR DESCRIPTION
Also cleaned up a quirk with the way messages were printed, `defer` was not appropriate here. Alleviates issues in #9, going to now try using `/v1/chat/completions` and GPT-4 or fine-tuning `text-davinci-003`.